### PR TITLE
adding back ability to rehydrate from given filterState prop (saves)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10160,7 +10160,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10525,7 +10526,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10573,6 +10575,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10611,11 +10614,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/src/ArcgisFilter/ArcgisFilter.js
+++ b/src/ArcgisFilter/ArcgisFilter.js
@@ -53,6 +53,18 @@ class ArcgisFilter extends Component {
       });
   }
 
+  componentDidUpdate = (prevProps, prevState) => {
+    // check if rehydrating from filterState
+    if (
+      JSON.stringify(prevProps.filterState) !==
+      JSON.stringify(this.props.filterState)
+    ) {
+      this.setState({ ...this.props.filterState }, () => {
+        this.onChange(this.state);
+      });
+    }
+  };
+
   onChange = state => {
     const filter = buildFilter(state);
     this.props.onChange(filter, state);


### PR DESCRIPTION
The ability to rehydrate a filter from a give filterState was removed in 0.8.0. This fix adds it back in.